### PR TITLE
changed babel-preset-2015 to babel-preset-env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015"]
+  "presets": ["env"]
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "assert": "^1.3.0",
     "babel-core": "^6.4.5",
-    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-env": "^1.6.0",
     "expect.js": "^0.3.1",
     "gulp": "^3.9.0",
     "gulp-concat": "^2.6.0",


### PR DESCRIPTION
I updated babel-preset-2015 to babel-preset-env, which is now the recommended way. 
Setting yearly presets throws a bunch of warnings, so it would be great if you could accept this PR.
